### PR TITLE
Fix check in GetTableForName

### DIFF
--- a/BucHelp/DatabaseServices/CSVDriver.cs
+++ b/BucHelp/DatabaseServices/CSVDriver.cs
@@ -50,9 +50,9 @@ namespace BucHelp.DatabaseServices
 
         public ITable GetTableForName(string name)
         {
+            if (!tables.ContainsKey(name) || !headers.ContainsKey(name)) return null;
             RowHeader rowHeader = headers[name];
             List<Row> rows = tables[name];
-            if (rows == null || rowHeader == null) return null;
             return tableHandles.GetValueOrDefault(name, new CSVTableHandle(rowHeader, rows));
         }
 


### PR DESCRIPTION
Fixes issue when GetTableForName relies on dictionaries returning null to indicate no key, which C# does not do; it throws an exception instead, breaking the API contract.